### PR TITLE
python2.6 compatibility related.

### DIFF
--- a/firebase/firebase_token_generator.py
+++ b/firebase/firebase_token_generator.py
@@ -97,7 +97,7 @@ class FirebaseTokenGenerator(object):
         return encoded.decode('utf-8').replace('=', '')
 
     def _encode_json(self, obj):
-        return self._encode(bytearray(json.dumps(obj), 'utf-8'))
+        return self._encode(json.dumps(obj).encode("utf-8"))
 
     def _sign(self, secret, to_sign):
         def portable_bytes(s):

--- a/firebase/jsonutil.py
+++ b/firebase/jsonutil.py
@@ -2,13 +2,18 @@ import datetime
 import json
 import decimal
 
+try:
+    total_seconds = datetime.timedelta.total_seconds
+except AttributeError:
+    total_seconds = lambda self: ((self.days * 86400 + self.seconds) * 10 ** 6 + self.microseconds) / 10 ** 6.0
+
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
         elif isinstance(obj, datetime.timedelta):
-            return int(obj.total_seconds())
+            return total_seconds(obj)
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
         else:

--- a/tests/jsonutil_test.py
+++ b/tests/jsonutil_test.py
@@ -15,9 +15,21 @@ class JSONTestCase(unittest.TestCase):
     def test_conversion(self):
         serialized = json.dumps(self.data, cls=JSONEncoder)
         deserialized = json.loads(serialized)
-        self.assertEqual(deserialized['oneday'],
-                         int(self.data['oneday'].total_seconds()))
+        self.assertEqual(deserialized['oneday'], 86400)
         self.assertTrue(type(deserialized['five']) == float)
         self.assertEqual(deserialized['five'], float(5))
         self.assertEqual(deserialized['now'], str(self.data['now'].isoformat()))
+
+    def test_total_seconds(self):
+        from firebase.jsonutil import total_seconds
+
+        delta = datetime.timedelta(days=1,
+                                   seconds=3,
+                                   microseconds=440000,
+                                   milliseconds=3300,
+                                   minutes=5,
+                                   hours=2,
+                                   weeks=2)
+
+        self.assertEqual(total_seconds(delta), 1303506.74)
 


### PR DESCRIPTION
in py2.6 datetime.timedelta doesn't have total_seconds method.
base64.urlsafe_b64encode doesn't work with bytearray
