### PR TITLE
'put' same behaviour as 'put_async' when 'name' is None

### DIFF
--- a/firebase/firebase.py
+++ b/firebase/firebase.py
@@ -292,7 +292,7 @@ class FirebaseApplication(object):
         the server, because the request will be made with ``silent``
         parameter. ``data`` must be a JSONable value.
         """
-        assert name, 'Snapshot name must be specified'
+        if name is None: name = ''
         params = params or {}
         headers = headers or {}
         endpoint = self._build_endpoint_url(url, name)


### PR DESCRIPTION
The old behaviour causes an assertion error when name == 0