### PR TITLE
endpoint: build url as endpoint.json when name is empty or None

### DIFF
--- a/firebase/firebase.py
+++ b/firebase/firebase.py
@@ -239,10 +239,10 @@ class FirebaseApplication(object):
         full_url = _build_endpoint_url('/users', '1')
         full_url => 'http://firebase.localhost/users/1.json'
         """
+        if (name is None) or (name is ''):
+            return '%s%s' % (urlparse.urljoin(self.dsn, url), self.NAME_EXTENSION)
         if not url.endswith(self.URL_SEPERATOR):
             url = url + self.URL_SEPERATOR
-        if name is None:
-            name = ''
         return '%s%s%s' % (urlparse.urljoin(self.dsn, url), name,
                            self.NAME_EXTENSION)
 

--- a/tests/firebase_test.py
+++ b/tests/firebase_test.py
@@ -59,7 +59,7 @@ class FirebaseTestCase(unittest.TestCase):
     def test_build_endpoint_url(self):
         url1 = os.path.join(self.DSN, 'users', '1.json')
         self.assertEqual(self.firebase._build_endpoint_url('/users', '1'), url1)
-        url2 = os.path.join(self.DSN, 'users/1/.json')
+        url2 = os.path.join(self.DSN, 'users/1.json')
         self.assertEqual(self.firebase._build_endpoint_url('/users/1', None), url2)
 
     def test_make_get_request(self):


### PR DESCRIPTION
Rationale:

Firebase supports http://yourapp.com/storage.json

All examples of API are like that.