### PR TITLE
register atexit callback and import multiprocessing module only when process_pool is initialized.

### DIFF
--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -1,15 +1,1 @@
-import atexit
-
-from .async import process_pool
 from firebase import *
-
-
-@atexit.register
-def close_process_pool():
-    """
-    Clean up function that closes and terminates the process pool
-    defined in the ``async`` file.
-    """
-    process_pool.close()
-    process_pool.join()
-    process_pool.terminate()

--- a/firebase/async.py
+++ b/firebase/async.py
@@ -1,14 +1,37 @@
-import multiprocessing
-
+import threading
 from .lazy import LazyLoadProxy
 
 __all__ = ['process_pool']
 
 _process_pool = None
+_singleton_lock = threading.Lock()
+
+
 def get_process_pool(size=5):
     global _process_pool
-    if _process_pool is None:
-        _process_pool = multiprocessing.Pool(processes=size)
-    return _process_pool
-process_pool = LazyLoadProxy(get_process_pool)
+    global _singleton_lock
 
+    if _process_pool is not None:
+        return _process_pool
+
+    # initialize process_pool thread safe way
+    with _singleton_lock:
+        if _process_pool is None:
+            import atexit
+            import multiprocessing
+            _process_pool = multiprocessing.Pool(processes=size)
+
+            # atexit will work only if multiprocessing pool is initialized.
+            @atexit.register
+            def close_process_pool():
+                """
+                Clean up function that closes and terminates the process pool
+                """
+                _process_pool.close()
+                _process_pool.join()
+                _process_pool.terminate()
+
+    return _process_pool
+
+
+process_pool = LazyLoadProxy(get_process_pool)


### PR DESCRIPTION
register atexit callback and import multiprocessing module only when process_pool is initialized.

1. Process pool is initialized by thread safe way.
2. atexit callback only registered at the same time with process_pool initializing. So both of them are singleton in threaded env. #9 
3. "multiprocessing import" delayed as much as possible. this helps google app engine import issues. #18 
test need for pull requests.