### PR TITLE
Modify requests ReadTimeout

### DIFF
--- a/firebase/decorators.py
+++ b/firebase/decorators.py
@@ -14,7 +14,9 @@ def http_connection(timeout):
                 kwargs['connection'] = connection
             else:
                 connection = kwargs['connection']
-            connection.timeout = timeout
+
+            if not getattr(connection, 'timeout', False):
+                connection.timeout = timeout
             connection.headers.update({'Content-type': 'application/json'})
             return f(*args, **kwargs)
         return wraps(f)(wrapped)


### PR DESCRIPTION
Add ability to customize requests ReadTimeout if session with timeout attribute is passed in, otherwise default to decorators value.

Allows you to pass in your own requests.Session() object with a `timeout` field. This allows people to have a customized ReadTimeout that is much shorter than the default 60 seconds. Useful when Firebase is having intermittent server issues, so retrys can happen at a quicker rate.
