### PR TITLE
Update firebase.py

### DIFF
--- a/firebase/firebase.py
+++ b/firebase/firebase.py
@@ -1,8 +1,6 @@
-try:
-    import urlparse
-except ImportError:
-    #py3k
-    from urllib import parse as urlparse
+
+# just use python 3.
+from urllib import parse as urlparse
 
 import json
 


### PR DESCRIPTION
urlpaste error is fixed in python3. python2 should not be used.